### PR TITLE
update install instructions for casual users

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ pip install gps
 
 Clone this repository and install.
 ```bash
-git clone git@github.com:astrochart/CHART.git
+git clone https://github.com/astrochart/CHART.git
 cd CHART
-python setup.py install
+python setup.py install --user
 ```
 
 ---


### PR DESCRIPTION
Use the https clone so users don't need to have a github account setup. Also install for user, not global install.